### PR TITLE
Build marketing site for Gjaltema Films

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
-# GjaltemaFilms
-Website voor Gjaltema Films 
+# Gjaltema Films website
+
+Statische, snelle en toegankelijke marketingwebsite voor videoproductiebedrijf **Gjaltema Films**. Ontworpen in vanilla HTML/CSS/JS met focus op conversie, SEO en WCAG 2.1 AA-eisen.
+
+## Te vervangen gegevens
+- `jouw@e-mail.nl` &rarr; vervang door het gewenste contactadres (komt voor in HTML, privacyverklaring en manifest).
+- Formspree-endpoint `https://formspree.io/f/your-form-id` &rarr; vervang door je eigen Formspree-ID.
+- Telefoonnummer `06-…` en `tel:06` &rarr; vul het juiste nummer in.
+- Adresinformatie `Straat, Plaats` &rarr; actualiseren.
+- KvK- en BTW-nummers `nummer` &rarr; invullen.
+- Social links (`href="#"`) &rarr; vervang door echte Instagram/YouTube/LinkedIn URL's.
+- Vanaf-prijzen `€ …` &rarr; vul concrete bedragen in.
+- Sitemap/robots domein `https://www.gjaltemafilms.nl/` &rarr; wijzig indien je een ander domein gebruikt.
+
+## Structuur
+```
+.
+├── index.html           # Hoofdpagina met alle secties
+├── privacy.html         # Privacyverklaring + cookieparagraaf
+├── assets/
+│   ├── css/styles.css   # Gestyleerde componenten en layout
+│   ├── js/main.js       # Navigatie, lightbox, formulierlogica
+│   ├── icons/favicon.svg
+│   └── img/             # SVG assets en portfolio placeholders
+├── manifest.json        # PWA/icoon-meta-informatie
+├── robots.txt           # Crawling-instructies
+├── sitemap.xml          # Sitemap voor zoekmachines
+└── README.md
+```
+
+## Ontwikkeling
+- Geen build-stap nodig; open `index.html` rechtstreeks in de browser of host de map via GitHub Pages / Netlify.
+- Styles zijn mobiel-first met CSS Grid en flexbox.
+- JavaScript valideert het contactformulier, beheert de portfolio-lightbox en het mobiele menu.
+
+## Contactformulier instellen
+1. Maak een gratis Formspree-project en kopieer het formulier-ID (bijvoorbeeld `https://formspree.io/f/abcd1234`).
+2. Vervang de `action`-waarde in `index.html` bij `<form id="contact-form" ...>` door je Formspree-URL.
+3. Voeg in Formspree het gewenste ontvangstadres toe (bij voorkeur hetzelfde als `mailto:` in de site).
+4. Test het formulier via de live omgeving en controleer de bevestigingsmail.
+
+## Deployen op GitHub Pages
+1. Push de inhoud van deze map naar de `main`-branch van je GitHub-repo.
+2. Activeer **Settings → Pages → Branch: main (/root)**.
+3. Voeg eventueel een CNAME-record toe als je een eigen domein gebruikt.
+4. Werk `robots.txt` en `sitemap.xml` bij met de definitieve domeinnaam.
+
+## Toegankelijkheid & performance
+- Contrasten voldoen aan WCAG 2.1 AA (accentkleur #C9A227 op donker).
+- Navigatie volledig toetsenbordbedienbaar; skiplink aanwezig.
+- Afbeeldingen gebruiken `loading="lazy"` en alt-teksten.
+- Geen externe scripts behalve Google Fonts.
+
+## Privacy
+- `privacy.html` bevat de privacyverklaring en vermeldt dat uitsluitend functionele cookies worden gebruikt.
+- Voeg indien nodig extra paragrafen toe als er nieuwe tooling of tracking wordt toegevoegd.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,721 @@
+:root {
+  color-scheme: dark light;
+  --color-bg: #121212;
+  --color-surface: #1b1b1b;
+  --color-surface-alt: #161616;
+  --color-text: #f8f8f8;
+  --color-muted: #c5c5c5;
+  --color-accent: #c9a227;
+  --color-accent-strong: #e0bc4a;
+  --font-base: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-heading: 'Poppins', 'Montserrat', var(--font-base);
+  --max-width: 1200px;
+  --container-padding: clamp(1.2rem, 1.8vw + 1rem, 3rem);
+  --shadow-medium: 0 20px 45px rgba(0, 0, 0, 0.35);
+  --transition: 200ms ease;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-base);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  height: auto;
+}
+
+h1, h2, h3 {
+  font-family: var(--font-heading);
+  line-height: 1.2;
+  margin: 0 0 0.6em;
+}
+
+p {
+  margin: 0 0 1em;
+}
+
+ul, ol {
+  padding-left: 1.2rem;
+}
+
+.container {
+  width: min(100%, var(--max-width));
+  margin: 0 auto;
+  padding: 0 var(--container-padding);
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 1rem;
+  background: var(--color-accent);
+  color: #000;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  z-index: 999;
+}
+
+.skip-link:focus {
+  left: 1rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: rgba(18, 18, 18, 0.92);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 4.5rem;
+  gap: 1rem;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  background: var(--color-accent);
+  color: #121212;
+  font-family: var(--font-heading);
+  font-weight: 600;
+}
+
+.brand-text {
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+}
+
+.site-nav {
+  position: relative;
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: 0;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.04);
+  color: inherit;
+}
+
+.nav-toggle span[aria-hidden="true"]::before,
+.nav-toggle span[aria-hidden="true"]::after,
+.nav-toggle span[aria-hidden="true"] {
+  display: block;
+  width: 1.6rem;
+  height: 0.14rem;
+  margin: 0.35rem auto;
+  background-color: var(--color-text);
+  border-radius: 999px;
+  transition: transform var(--transition), opacity var(--transition);
+  content: '';
+}
+
+.nav-list {
+  display: flex;
+  gap: clamp(0.5rem, 2vw, 2rem);
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-list a {
+  color: var(--color-text);
+  font-weight: 500;
+  font-size: 0.95rem;
+  padding: 0.35rem 0;
+}
+
+.nav-list a:focus-visible,
+.button:focus-visible {
+  outline: 2px solid var(--color-accent-strong);
+  outline-offset: 3px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.8rem 1.6rem;
+  font-weight: 600;
+  transition: background-color var(--transition), transform var(--transition), box-shadow var(--transition);
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.button-primary {
+  background: var(--color-accent);
+  color: #121212;
+}
+
+.button-primary:hover,
+.button-primary:focus-visible {
+  background: var(--color-accent-strong);
+  box-shadow: 0 12px 24px rgba(201, 162, 39, 0.35);
+}
+
+.button-secondary {
+  background: transparent;
+  color: var(--color-text);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.button-secondary:hover,
+.button-secondary:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.hero {
+  padding: clamp(4rem, 7vw, 8rem) 0;
+  background: radial-gradient(circle at top right, rgba(201, 162, 39, 0.12), transparent 50%), var(--color-bg);
+}
+
+.hero-grid {
+  display: grid;
+  gap: clamp(2rem, 4vw, 4rem);
+  align-items: center;
+}
+
+.hero-text h1 {
+  font-size: clamp(2.4rem, 4vw, 3.6rem);
+}
+
+.lead {
+  font-size: clamp(1.05rem, 1.4vw + 0.9rem, 1.3rem);
+  color: var(--color-muted);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.22em;
+  color: var(--color-accent);
+  margin-bottom: 0.6rem;
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 2rem 0 2.5rem;
+}
+
+.trust-points {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  margin: 0;
+}
+
+.trust-points dt {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.trust-points dd {
+  margin: 0.3rem 0 0;
+  color: var(--color-muted);
+}
+
+.hero-media {
+  border-radius: 1.5rem;
+  overflow: hidden;
+  box-shadow: var(--shadow-medium);
+}
+
+.section {
+  padding: clamp(4rem, 6vw, 6rem) 0;
+}
+
+.section-alt {
+  background: var(--color-surface);
+}
+
+.section-heading {
+  max-width: 700px;
+  margin-bottom: clamp(2rem, 4vw, 3rem);
+}
+
+.section-heading p {
+  color: var(--color-muted);
+}
+
+.service-grid {
+  display: grid;
+  gap: clamp(1.6rem, 2vw, 2.2rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.service-card {
+  background: var(--color-surface-alt);
+  padding: 1.75rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.service-card h3 {
+  font-size: 1.4rem;
+}
+
+.service-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--color-muted);
+}
+
+.portfolio-grid {
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.portfolio-item {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.portfolio-item figure {
+  margin: 0;
+  display: grid;
+}
+
+.portfolio-item img {
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  object-fit: cover;
+}
+
+.portfolio-item figcaption {
+  padding: 1.25rem;
+  background: var(--color-surface-alt);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.portfolio-item .tag {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-accent);
+}
+
+.portfolio-item .title {
+  font-family: var(--font-heading);
+  font-size: 1.3rem;
+}
+
+.portfolio-item .description {
+  color: var(--color-muted);
+}
+
+.portfolio-item:focus-visible,
+.portfolio-item:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-medium);
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 999;
+}
+
+.lightbox[data-state="visible"] {
+  display: flex;
+}
+
+.lightbox-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+}
+
+.lightbox-content {
+  position: relative;
+  background: var(--color-surface);
+  border-radius: 1.25rem;
+  padding: clamp(1.5rem, 2vw, 2rem);
+  max-width: 900px;
+  width: min(100%, 900px);
+  box-shadow: var(--shadow-medium);
+}
+
+.lightbox-media iframe {
+  width: 100%;
+  min-height: clamp(220px, 56vw, 500px);
+  border: 0;
+  border-radius: 0.75rem;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text);
+  border: 0;
+  font-size: 1.8rem;
+  cursor: pointer;
+}
+
+.process-list {
+  display: grid;
+  gap: 1.4rem;
+  list-style: none;
+  margin: 0;
+  counter-reset: step;
+  padding: 0;
+}
+
+.process-list li {
+  background: var(--color-surface-alt);
+  padding: 1.8rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  position: relative;
+  padding-left: 4.5rem;
+}
+
+.process-list li::before {
+  counter-increment: step;
+  content: counter(step);
+  position: absolute;
+  left: 1.4rem;
+  top: 1.6rem;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  background: rgba(201, 162, 39, 0.15);
+  color: var(--color-accent);
+  font-weight: 600;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-heading);
+}
+
+.two-column {
+  display: grid;
+  gap: clamp(2rem, 4vw, 4rem);
+  align-items: start;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.credentials {
+  margin: 2rem 0 0;
+  padding-left: 1.1rem;
+  color: var(--color-muted);
+}
+
+.contact-highlight {
+  background: var(--color-surface-alt);
+  padding: 2rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-highlight ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.contact-highlight a {
+  font-weight: 600;
+}
+
+.socials {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.socials a {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.pricing-grid {
+  display: grid;
+  gap: clamp(1.6rem, 3vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.pricing-card {
+  background: var(--color-surface-alt);
+  padding: 2rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.pricing-card .price {
+  font-size: 2rem;
+  font-family: var(--font-heading);
+  color: var(--color-accent);
+}
+
+.pricing-note {
+  margin-top: 2rem;
+  color: var(--color-muted);
+}
+
+.faq-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.faq-list details {
+  background: var(--color-surface-alt);
+  padding: 1.2rem 1.4rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.faq-list summary {
+  cursor: pointer;
+  font-weight: 600;
+  list-style: none;
+}
+
+.faq-list summary::-webkit-details-marker {
+  display: none;
+}
+
+.contact-section {
+  background: var(--color-surface);
+}
+
+.contact-grid {
+  display: grid;
+  gap: clamp(2rem, 4vw, 4rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.contact-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.honeypot {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.form-field label {
+  font-weight: 600;
+}
+
+.form-field input,
+.form-field textarea {
+  width: 100%;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(12, 12, 12, 0.7);
+  color: var(--color-text);
+  font: inherit;
+}
+
+.form-field input:focus,
+.form-field textarea:focus {
+  border-color: var(--color-accent);
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(201, 162, 39, 0.2);
+}
+
+.checkbox-field {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 0.6rem;
+}
+
+.checkbox-field input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-top: 0.25rem;
+}
+
+.checkbox-field .error {
+  grid-column: 1 / -1;
+}
+
+.error {
+  color: #ffb3b3;
+  font-size: 0.85rem;
+  min-height: 1.1rem;
+}
+
+.form-feedback {
+  min-height: 1.25rem;
+  color: var(--color-muted);
+}
+
+.form-feedback.error-message {
+  color: #ffb3b3;
+}
+
+.form-feedback.info-message {
+  color: var(--color-muted);
+}
+
+.form-feedback.success {
+  color: #b8f5c3;
+}
+
+.site-footer {
+  padding: clamp(3rem, 4vw, 4rem) 0 2rem;
+  background: #0c0c0c;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.footer-grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.footer-title {
+  font-size: 1.5rem;
+}
+
+.footer-contact,
+.footer-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.footer-links a {
+  color: var(--color-muted);
+}
+
+.footer-bottom {
+  margin-top: 2rem;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 900px) {
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .nav-list {
+    position: absolute;
+    right: 0;
+    top: 3.5rem;
+    flex-direction: column;
+    align-items: stretch;
+    background: rgba(18, 18, 18, 0.98);
+    border-radius: 1rem;
+    padding: 1rem;
+    min-width: 200px;
+    box-shadow: var(--shadow-medium);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-10px);
+    transition: opacity var(--transition), transform var(--transition);
+  }
+
+  .nav-list[data-open="true"] {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  .contact-shortcut {
+    display: none;
+  }
+}
+
+@media (min-width: 900px) {
+  .hero-grid {
+    grid-template-columns: 1.1fr 0.9fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/assets/icons/favicon.svg
+++ b/assets/icons/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#121212" />
+  <path d="M18 20h28l-4 8h-20l6 12h10l-3 6h-10z" fill="#C9A227" />
+  <circle cx="32" cy="32" r="30" fill="none" stroke="#C9A227" stroke-width="2" opacity="0.6" />
+</svg>

--- a/assets/img/og-image.svg
+++ b/assets/img/og-image.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Gjaltema Films Open Graph Afbeelding</title>
+  <desc id="desc">Donkere achtergrond met gouden accent en tekst die Gjaltema Films promoot.</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1c1c1c" />
+      <stop offset="100%" stop-color="#121212" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#grad)" />
+  <rect x="70" y="120" width="180" height="12" fill="#C9A227" />
+  <text x="600" y="260" fill="#FFFFFF" font-size="72" font-family="'Poppins', 'Montserrat', sans-serif" text-anchor="middle">Gjaltema Films</text>
+  <text x="600" y="350" fill="#C9A227" font-size="36" font-family="'Inter', sans-serif" text-anchor="middle">Strakke video die jouw verhaal laat werken</text>
+  <rect x="70" y="480" width="1060" height="60" rx="12" ry="12" fill="#1f1f1f" stroke="#2d2d2d" />
+  <text x="600" y="520" fill="#FFFFFF" font-size="30" font-family="'Inter', sans-serif" text-anchor="middle">Bedrijfsvideo's · Events · Drone · Socials</text>
+</svg>

--- a/assets/img/portfolio/project-1.svg
+++ b/assets/img/portfolio/project-1.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title desc">
+  <title id="title">Drone overzicht</title>
+  <desc id="desc">Illustratieve thumbnail voor drone project met goud accent.</desc>
+  <defs>
+    <linearGradient id="bg1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a1a1a" />
+      <stop offset="100%" stop-color="#121212" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" fill="url(#bg1)" />
+  <path d="M80 90h440v6H80z" fill="#C9A227" />
+  <text x="60" y="170" fill="#FFFFFF" font-size="44" font-family="'Poppins', sans-serif">Drone overzicht</text>
+  <text x="60" y="230" fill="#C9A227" font-size="24" font-family="'Inter', sans-serif">Drone</text>
+  <circle cx="500" cy="300" r="60" stroke="#C9A227" stroke-width="6" fill="none" />
+  <path d="M500 255l-24 32h48z" fill="#C9A227" />
+</svg>

--- a/assets/img/portfolio/project-2.svg
+++ b/assets/img/portfolio/project-2.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title desc">
+  <title id="title">Event hoogtepunten</title>
+  <desc id="desc">Thumbnail voor eventregistratie met podiumillustratie.</desc>
+  <rect width="600" height="400" fill="#121212" />
+  <rect x="0" y="0" width="600" height="160" fill="#1d1d1d" />
+  <rect x="60" y="70" width="120" height="20" fill="#C9A227" />
+  <text x="60" y="220" fill="#FFFFFF" font-size="44" font-family="'Poppins', sans-serif">Event hoogtepunten</text>
+  <text x="60" y="280" fill="#C9A227" font-size="24" font-family="'Inter', sans-serif">Event</text>
+  <g fill="#FFFFFF">
+    <circle cx="420" cy="280" r="42" fill="#1d1d1d" stroke="#C9A227" stroke-width="6" />
+    <rect x="394" y="310" width="52" height="12" fill="#C9A227" />
+  </g>
+</svg>

--- a/assets/img/portfolio/project-3.svg
+++ b/assets/img/portfolio/project-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title desc">
+  <title id="title">Bedrijfsshoot</title>
+  <desc id="desc">Illustratieve thumbnail voor bedrijfsvideo met storyboard-element.</desc>
+  <rect width="600" height="400" fill="#101010" />
+  <rect x="40" y="60" width="520" height="280" rx="12" fill="#181818" stroke="#2a2a2a" stroke-width="4" />
+  <rect x="60" y="90" width="180" height="16" fill="#C9A227" />
+  <text x="60" y="220" fill="#FFFFFF" font-size="44" font-family="'Poppins', sans-serif">Bedrijfsshoot</text>
+  <text x="60" y="280" fill="#C9A227" font-size="24" font-family="'Inter', sans-serif">Videoproductie</text>
+  <rect x="360" y="120" width="160" height="100" fill="#1f1f1f" stroke="#C9A227" stroke-width="4" />
+  <line x1="360" y1="170" x2="520" y2="170" stroke="#C9A227" stroke-width="4" />
+  <line x1="440" y1="120" x2="440" y2="220" stroke="#C9A227" stroke-width="4" />
+</svg>

--- a/assets/img/portfolio/project-4.svg
+++ b/assets/img/portfolio/project-4.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title desc">
+  <title id="title">Social snippet</title>
+  <desc id="desc">Thumbnail voor social content met mobiele preview.</desc>
+  <rect width="600" height="400" fill="#111111" />
+  <rect x="420" y="60" width="120" height="240" rx="18" fill="#1c1c1c" stroke="#C9A227" stroke-width="4" />
+  <rect x="438" y="90" width="84" height="80" fill="#181818" />
+  <rect x="438" y="190" width="84" height="20" fill="#C9A227" />
+  <text x="60" y="200" fill="#FFFFFF" font-size="44" font-family="'Poppins', sans-serif">Social snippet</text>
+  <text x="60" y="260" fill="#C9A227" font-size="24" font-family="'Inter', sans-serif">Social</text>
+  <circle cx="480" cy="324" r="8" fill="#C9A227" />
+</svg>

--- a/assets/img/portfolio/project-5.svg
+++ b/assets/img/portfolio/project-5.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title desc">
+  <title id="title">Productvideo</title>
+  <desc id="desc">Thumbnail voor productvideo met lichtaccent.</desc>
+  <rect width="600" height="400" fill="#101010" />
+  <ellipse cx="180" cy="200" rx="110" ry="150" fill="#181818" />
+  <ellipse cx="180" cy="200" rx="70" ry="100" fill="#C9A227" opacity="0.3" />
+  <text x="60" y="200" fill="#FFFFFF" font-size="44" font-family="'Poppins', sans-serif">Productvideo</text>
+  <text x="60" y="260" fill="#C9A227" font-size="24" font-family="'Inter', sans-serif">Product</text>
+  <rect x="320" y="160" width="220" height="120" fill="#1f1f1f" stroke="#C9A227" stroke-width="4" />
+  <polygon points="420,190 460,220 420,250" fill="#C9A227" />
+</svg>

--- a/assets/img/portfolio/project-6.svg
+++ b/assets/img/portfolio/project-6.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title desc">
+  <title id="title">Aftermovie</title>
+  <desc id="desc">Thumbnail voor aftermovie met lichtbalken.</desc>
+  <rect width="600" height="400" fill="#0f0f0f" />
+  <rect x="60" y="80" width="40" height="240" fill="#1d1d1d" />
+  <rect x="120" y="80" width="40" height="240" fill="#2a2a2a" />
+  <rect x="460" y="80" width="40" height="240" fill="#1d1d1d" />
+  <rect x="400" y="80" width="40" height="240" fill="#2a2a2a" />
+  <rect x="260" y="80" width="80" height="240" fill="#C9A227" opacity="0.7" />
+  <text x="60" y="200" fill="#FFFFFF" font-size="44" font-family="'Poppins', sans-serif">Aftermovie</text>
+  <text x="60" y="260" fill="#C9A227" font-size="24" font-family="'Inter', sans-serif">Event</text>
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,182 @@
+(function () {
+  const navToggle = document.querySelector('.nav-toggle');
+  const navList = document.getElementById('primary-navigation');
+  const contactForm = document.getElementById('contact-form');
+  const feedbackEl = contactForm?.querySelector('.form-feedback');
+  const yearEl = document.getElementById('year');
+  const lightbox = document.querySelector('.lightbox');
+  const lightboxMedia = document.querySelector('[data-embed-target]');
+  const closeButton = document.querySelector('.lightbox-close');
+  const backdrop = document.querySelector('[data-lightbox-close]');
+
+  if (yearEl) {
+    yearEl.textContent = new Date().getFullYear();
+  }
+
+  if (navToggle && navList) {
+    navToggle.addEventListener('click', () => {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      navToggle.setAttribute('aria-expanded', String(!expanded));
+      if (!expanded) {
+        navList.dataset.open = 'true';
+      } else {
+        delete navList.dataset.open;
+      }
+    });
+
+    navList.addEventListener('click', (event) => {
+      if (event.target instanceof HTMLElement && event.target.tagName === 'A') {
+        navToggle.setAttribute('aria-expanded', 'false');
+        delete navList.dataset.open;
+      }
+    });
+  }
+
+  const setError = (fieldId, message) => {
+    const errorEl = contactForm?.querySelector(`.error[data-error-for="${fieldId}"]`);
+    if (errorEl) {
+      errorEl.textContent = message;
+    }
+  };
+
+  const clearError = (fieldId) => {
+    const errorEl = contactForm?.querySelector(`.error[data-error-for="${fieldId}"]`);
+    if (errorEl) {
+      errorEl.textContent = '';
+    }
+  };
+
+  const validateEmail = (value) => {
+    const pattern = /^(?:[a-zA-Z0-9_'^&+%!-]+(?:\.[a-zA-Z0-9_'^&+%!-]+)*)@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
+    return pattern.test(value);
+  };
+
+  contactForm?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!contactForm || !feedbackEl) return;
+
+    const formData = new FormData(contactForm);
+    const honeypot = formData.get('website');
+    let valid = true;
+
+    const naam = contactForm.querySelector('#naam');
+    if (naam instanceof HTMLInputElement) {
+      if (!naam.value.trim()) {
+        valid = false;
+        setError('naam', 'Vul je naam in.');
+      } else {
+        clearError('naam');
+      }
+    }
+
+    const email = contactForm.querySelector('#email');
+    if (email instanceof HTMLInputElement) {
+      if (!email.value.trim()) {
+        valid = false;
+        setError('email', 'Vul je e-mailadres in.');
+      } else if (!validateEmail(email.value)) {
+        valid = false;
+        setError('email', 'Voer een geldig e-mailadres in.');
+      } else {
+        clearError('email');
+      }
+    }
+
+    const bericht = contactForm.querySelector('#bericht');
+    if (bericht instanceof HTMLTextAreaElement) {
+      if (!bericht.value.trim()) {
+        valid = false;
+        setError('bericht', 'Vertel kort waar we mee kunnen helpen.');
+      } else {
+        clearError('bericht');
+      }
+    }
+
+    const gdpr = contactForm.querySelector('#gdpr');
+    if (gdpr instanceof HTMLInputElement) {
+      if (!gdpr.checked) {
+        valid = false;
+        setError('gdpr', 'Vink de toestemming aan om verder te gaan.');
+      } else {
+        clearError('gdpr');
+      }
+    }
+
+    if (honeypot) {
+      return;
+    }
+
+    if (!valid) {
+      feedbackEl.textContent = 'Controleer de gemarkeerde velden.';
+      feedbackEl.classList.remove('success', 'info-message');
+      feedbackEl.classList.add('error-message');
+      return;
+    }
+
+    feedbackEl.textContent = 'Versturen…';
+    feedbackEl.classList.remove('error-message', 'success');
+    feedbackEl.classList.add('info-message');
+
+    try {
+      const response = await fetch(contactForm.action, {
+        method: 'POST',
+        headers: { Accept: 'application/json' },
+        body: formData,
+      });
+
+      if (response.ok) {
+        feedbackEl.textContent = 'Bedankt! We nemen binnen één werkdag contact op.';
+        feedbackEl.classList.remove('info-message');
+        feedbackEl.classList.add('success');
+        contactForm.reset();
+      } else {
+        throw new Error('Netwerkfout');
+      }
+    } catch (error) {
+      console.error(error);
+      feedbackEl.textContent = 'Er ging iets mis bij het versturen. Probeer het later opnieuw of mail ons direct.';
+      feedbackEl.classList.remove('info-message');
+      feedbackEl.classList.add('error-message');
+    }
+  });
+
+  const portfolioItems = document.querySelectorAll('.portfolio-item');
+  const openLightbox = (embedUrl) => {
+    if (!lightbox || !lightboxMedia) return;
+    const iframe = document.createElement('iframe');
+    iframe.src = embedUrl;
+    iframe.allow = 'autoplay; fullscreen; picture-in-picture';
+    iframe.title = 'Video player';
+    iframe.loading = 'lazy';
+    lightboxMedia.innerHTML = '';
+    lightboxMedia.appendChild(iframe);
+    lightbox.dataset.state = 'visible';
+    document.body.style.overflow = 'hidden';
+    closeButton?.focus();
+  };
+
+  const closeLightbox = () => {
+    if (!lightbox || !lightboxMedia) return;
+    lightbox.dataset.state = 'hidden';
+    lightboxMedia.innerHTML = '';
+    document.body.style.overflow = '';
+  };
+
+  portfolioItems.forEach((item) => {
+    item.addEventListener('click', () => {
+      const embed = item.getAttribute('data-embed');
+      if (embed) {
+        openLightbox(embed);
+      }
+    });
+  });
+
+  closeButton?.addEventListener('click', closeLightbox);
+  backdrop?.addEventListener('click', closeLightbox);
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && lightbox?.dataset.state === 'visible') {
+      closeLightbox();
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,459 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Gjaltema Films | Wij maken strakke video's die jouw verhaal laten werken</title>
+  <meta name="description" content="Gjaltema Films maakt bedrijfsvideo's, eventregistraties, drone-shots en social content in Groningen en Westerkwartier." />
+  <meta name="theme-color" content="#121212" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Gjaltema Films" />
+  <meta property="og:description" content="Strakke video die jouw verhaal laat werken. Videoproductie, events, drone en socials." />
+  <meta property="og:url" content="https://www.gjaltemafilms.nl/" />
+  <meta property="og:image" content="assets/img/og-image.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Gjaltema Films" />
+  <meta name="twitter:description" content="Videoproductie in Groningen en Westerkwartier." />
+  <meta name="twitter:image" content="assets/img/og-image.svg" />
+  <link rel="icon" type="image/svg+xml" href="assets/icons/favicon.svg" />
+  <link rel="manifest" href="manifest.json" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main">Direct naar inhoud</a>
+  <header class="site-header" id="top">
+    <div class="container">
+      <a class="brand" href="#top" aria-label="Gjaltema Films home">
+        <span class="brand-mark" aria-hidden="true">GF</span>
+        <span class="brand-text">Gjaltema Films</span>
+      </a>
+      <nav class="site-nav" aria-label="Hoofdmenu">
+        <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="sr-only">Menu</span>
+          <span aria-hidden="true"></span>
+        </button>
+        <ul id="primary-navigation" class="nav-list">
+          <li><a href="#diensten">Diensten</a></li>
+          <li><a href="#portfolio">Portfolio</a></li>
+          <li><a href="#werkwijze">Werkwijze</a></li>
+          <li><a href="#over-ons">Over ons</a></li>
+          <li><a href="#tarieven">Tarieven</a></li>
+          <li><a href="#faq">FAQ</a></li>
+        </ul>
+      </nav>
+      <a class="button button-primary contact-shortcut" href="#contact">Contact</a>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="container hero-grid">
+        <div class="hero-text">
+          <p class="eyebrow">Groningen &middot; Westerkwartier</p>
+          <h1 id="hero-title">Wij maken strakke video's die jouw verhaal laten werken.</h1>
+          <p class="lead">Wij zijn Gjaltema Films. We helpen bedrijven en evenementen met video die onthoudbaar is—van strak script tot stevige montage. Inclusief drone-shots wanneer het kan en mag.</p>
+          <p class="lead">Specialisaties: bedrijfsvideo's, eventregistratie, drone-shots &amp; socials.</p>
+          <div class="cta-group">
+            <a class="button button-primary" href="#contact">Offerte aanvragen</a>
+            <a class="button button-secondary" href="#portfolio">Portfolio bekijken</a>
+          </div>
+          <dl class="trust-points">
+            <div>
+              <dt>Heldere prijzen</dt>
+              <dd>Geen verrassingen achteraf, altijd een voorstel op maat.</dd>
+            </div>
+            <div>
+              <dt>Veilige drone-operaties</dt>
+              <dd>EU-gecertificeerd, we regelen de juiste vergunningen.</dd>
+            </div>
+            <div>
+              <dt>Korte lijnen</dt>
+              <dd>Eén contactpersoon en snelle terugkoppeling.</dd>
+            </div>
+          </dl>
+        </div>
+        <figure class="hero-media">
+          <img src="assets/img/portfolio/project-1.svg" width="600" height="400" loading="lazy" alt="Drone overzicht gefilmd door Gjaltema Films" />
+        </figure>
+      </div>
+    </section>
+
+    <section id="diensten" class="section" aria-labelledby="diensten-title">
+      <div class="container">
+        <div class="section-heading">
+          <h2 id="diensten-title">Diensten</h2>
+          <p>Videoproductie van script tot montage. We denken mee, filmen veilig en leveren voor web én socials.</p>
+        </div>
+        <div class="service-grid" role="list">
+          <article class="service-card" role="listitem">
+            <h3>Videoproductie</h3>
+            <p>Van script en storyboard tot opnames met meerdere camera's en strakke montage. We zorgen dat jouw verhaal landt.</p>
+            <ul>
+              <li>Concept &amp; scriptbegeleiding</li>
+              <li>Filmen met licht en audio-opstelling</li>
+              <li>Montage inclusief kleurcorrectie</li>
+            </ul>
+          </article>
+          <article class="service-card" role="listitem">
+            <h3>Drone video &amp; fotografie</h3>
+            <p>Gecertificeerd dronepiloot voor veilige vluchten en krachtige beelden vanuit de lucht.</p>
+            <ul>
+              <li>Vluchten volgens EU-regels</li>
+              <li>Vooraf locatie- en risicocheck</li>
+              <li>4K-video en hoge resolutie foto</li>
+            </ul>
+          </article>
+          <article class="service-card" role="listitem">
+            <h3>Social content</h3>
+            <p>Verticale edits, reels en shorts met snelle call-to-action. Altijd voorzien van titels en ondertiteling.</p>
+            <ul>
+              <li>Formaten voor Instagram, TikTok en LinkedIn</li>
+              <li>Snel inzetbare content batches</li>
+              <li>Voorzien van ondertitels en branding</li>
+            </ul>
+          </article>
+          <article class="service-card" role="listitem">
+            <h3>Eventregistratie</h3>
+            <p>We vangen de energie van jouw event met meerdere camera's, hoogwaardige audio en snelle leveringen.</p>
+            <ul>
+              <li>Meerdere camera-posities</li>
+              <li>Heldere audio van sprekers en publiek</li>
+              <li>Snelle highlight-versie voor socials</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="portfolio" class="section section-alt" aria-labelledby="portfolio-title">
+      <div class="container">
+        <div class="section-heading">
+          <h2 id="portfolio-title">Portfolio</h2>
+          <p>Selectie van recente producties. Vraag ons gerust naar meer cases of referenties.</p>
+        </div>
+        <div class="portfolio-grid">
+          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=dQw4w9WgXcQ" aria-label="Open project Drone overzicht">
+            <figure>
+              <img src="assets/img/portfolio/project-1.svg" width="600" height="400" loading="lazy" alt="Drone overzicht projectthumbnail" />
+              <figcaption>
+                <span class="tag">Drone</span>
+                <span class="title">Drone overzicht</span>
+                <span class="description">Luchtbeelden van bedrijfsterrein in Westerkwartier.</span>
+              </figcaption>
+            </figure>
+          </button>
+          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=oHg5SJYRHA0" aria-label="Open project Event hoogtepunten">
+            <figure>
+              <img src="assets/img/portfolio/project-2.svg" width="600" height="400" loading="lazy" alt="Event hoogtepunten projectthumbnail" />
+              <figcaption>
+                <span class="tag">Event</span>
+                <span class="title">Event hoogtepunten</span>
+                <span class="description">Aftermovie van congres met interviews en sfeer.</span>
+              </figcaption>
+            </figure>
+          </button>
+          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=ub82Xb1C8os" aria-label="Open project Bedrijfsshoot">
+            <figure>
+              <img src="assets/img/portfolio/project-3.svg" width="600" height="400" loading="lazy" alt="Bedrijfsshoot projectthumbnail" />
+              <figcaption>
+                <span class="tag">Videoproductie</span>
+                <span class="title">Bedrijfsshoot</span>
+                <span class="description">Employer branding video voor techbedrijf.</span>
+              </figcaption>
+            </figure>
+          </button>
+          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=VV1XWJN3nJo" aria-label="Open project Social snippet">
+            <figure>
+              <img src="assets/img/portfolio/project-4.svg" width="600" height="400" loading="lazy" alt="Social snippet projectthumbnail" />
+              <figcaption>
+                <span class="tag">Social</span>
+                <span class="title">Social snippet</span>
+                <span class="description">Maandelijkse short-form content voor campagne.</span>
+              </figcaption>
+            </figure>
+          </button>
+          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=ZZ5LpwO-An4" aria-label="Open project Productvideo">
+            <figure>
+              <img src="assets/img/portfolio/project-5.svg" width="600" height="400" loading="lazy" alt="Productvideo projectthumbnail" />
+              <figcaption>
+                <span class="tag">Product</span>
+                <span class="title">Productvideo</span>
+                <span class="description">Lancering van nieuw product met detailshots.</span>
+              </figcaption>
+            </figure>
+          </button>
+          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=2Z4m4lnjxkY" aria-label="Open project Aftermovie">
+            <figure>
+              <img src="assets/img/portfolio/project-6.svg" width="600" height="400" loading="lazy" alt="Aftermovie projectthumbnail" />
+              <figcaption>
+                <span class="tag">Event</span>
+                <span class="title">Aftermovie</span>
+                <span class="description">Festivalvastlegging met drone en crowdshots.</span>
+              </figcaption>
+            </figure>
+          </button>
+        </div>
+      </div>
+      <div class="lightbox" data-state="hidden" role="dialog" aria-modal="true" aria-labelledby="lightbox-title">
+        <div class="lightbox-content">
+          <button class="lightbox-close" type="button" aria-label="Sluit portfolio video">&times;</button>
+          <div class="lightbox-body" id="lightbox-body" role="document">
+            <h3 id="lightbox-title">Portfolio video</h3>
+            <div class="lightbox-media" data-embed-target></div>
+          </div>
+        </div>
+        <div class="lightbox-backdrop" data-lightbox-close></div>
+      </div>
+    </section>
+
+    <section id="werkwijze" class="section" aria-labelledby="werkwijze-title">
+      <div class="container">
+        <div class="section-heading">
+          <h2 id="werkwijze-title">Werkwijze</h2>
+          <p>Van kennismaking tot oplevering houden we het helder en wendbaar.</p>
+        </div>
+        <ol class="process-list">
+          <li>
+            <h3>Kennismaking</h3>
+            <p>We starten met een gesprek over doelen, doelgroep en planning. We denken mee over formats en kanalen.</p>
+          </li>
+          <li>
+            <h3>Plan &amp; script</h3>
+            <p>We werken een script of outline uit, inclusief shotlist, planning en logistiek.</p>
+          </li>
+          <li>
+            <h3>Opnames</h3>
+            <p>We filmen met de juiste crew, gear en, indien gewenst, drone. Veilig en efficiënt.</p>
+          </li>
+          <li>
+            <h3>Montage &amp; feedback</h3>
+            <p>We monteren snel, delen previews en verwerken revisies in overleg.</p>
+          </li>
+          <li>
+            <h3>Oplevering</h3>
+            <p>We leveren bestanden voor web, socials en archief. Inclusief ondertiteling en formaten.</p>
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <section id="over-ons" class="section section-alt" aria-labelledby="overons-title">
+      <div class="container two-column">
+        <div>
+          <h2 id="overons-title">Over ons</h2>
+          <p>We zijn Gjaltema Films uit Groningen en Westerkwartier. We houden van duidelijkheid: één contactpersoon, heldere planning en op tijd leveren. We denken mee, ook als je nog geen script hebt.</p>
+          <p>We werken voor organisaties in Noord-Nederland die video willen inzetten om te overtuigen, informeren en activeren.</p>
+          <ul class="credentials">
+            <li>EU drone-certificering &amp; verzekerde vluchten</li>
+            <li>Eigen apparatuur voor 4K &amp; slow-motion</li>
+            <li>Netwerk van regisseurs, editors en animators</li>
+          </ul>
+        </div>
+        <aside class="contact-highlight" aria-label="Contactgegevens">
+          <h3>Bereik ons</h3>
+          <ul>
+            <li><a href="mailto:jouw@e-mail.nl">jouw@e-mail.nl</a></li>
+            <li><a href="tel:+31600000000">06-…</a></li>
+            <li>Straat, Plaats</li>
+          </ul>
+          <div class="socials">
+            <a href="https://www.instagram.com/" aria-label="Instagram">Instagram</a>
+            <a href="https://www.youtube.com/" aria-label="YouTube">YouTube</a>
+            <a href="https://www.linkedin.com/" aria-label="LinkedIn">LinkedIn</a>
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <section id="tarieven" class="section" aria-labelledby="tarieven-title">
+      <div class="container">
+        <div class="section-heading">
+          <h2 id="tarieven-title">Tarieven</h2>
+          <p>Transparant en modulair. We maken graag een voorstel dat past bij jouw doelen.</p>
+        </div>
+        <div class="pricing-grid">
+          <article class="pricing-card">
+            <h3>Bedrijfsvideo</h3>
+            <p class="price">Vanaf € …</p>
+            <p>Inclusief scriptbegeleiding, opnamedag en montage.</p>
+          </article>
+          <article class="pricing-card">
+            <h3>Eventregistratie</h3>
+            <p class="price">Vanaf € …</p>
+            <p>Meerdere camera's, audio-opname en highlightvideo.</p>
+          </article>
+          <article class="pricing-card">
+            <h3>Drone-shots</h3>
+            <p class="price">Vanaf € …</p>
+            <p>Gecertificeerde piloot, voorbereiding en montage van ruwe shots.</p>
+          </article>
+        </div>
+        <p class="pricing-note">Indicatief; we maken graag een voorstel op maat.</p>
+      </div>
+    </section>
+
+    <section id="faq" class="section section-alt" aria-labelledby="faq-title">
+      <div class="container">
+        <div class="section-heading">
+          <h2 id="faq-title">Veelgestelde vragen</h2>
+          <p>Niet gevonden wat je zoekt? Neem gerust contact op.</p>
+        </div>
+        <div class="faq-list">
+          <details>
+            <summary>Wat is de gemiddelde levertijd?</summary>
+            <p>We leveren een eerste montage doorgaans binnen 7 tot 10 werkdagen na de opnames. Sneller nodig? Laat het ons weten, dan plannen we extra editcapaciteit.</p>
+          </details>
+          <details>
+            <summary>Hoe zit het met muziek- en beeldrechten?</summary>
+            <p>We licentiëren rechtenvrije muziek en zorgen voor duidelijke afspraken over gebruik van beeldmateriaal. Zo kun je de video zonder zorgen inzetten.</p>
+          </details>
+          <details>
+            <summary>Hoeveel revisierondes zijn inbegrepen?</summary>
+            <p>Standaard voorzien we twee revisierondes op de montage. Extra rondes kunnen altijd in overleg.</p>
+          </details>
+          <details>
+            <summary>Welke drone-regels gelden?</summary>
+            <p>We vliegen binnen de Europese regelgeving en regelen benodigde meldingen of ontheffingen. Indien de locatie niet kan, zoeken we een veilig alternatief.</p>
+          </details>
+          <details>
+            <summary>In welke formaten leveren jullie aan?</summary>
+            <p>Je ontvangt bestanden in 16:9 voor web en 9:16 of 1:1 voor socials. Andere formaten zijn op aanvraag mogelijk.</p>
+          </details>
+          <details>
+            <summary>Zorgen jullie voor ondertitels?</summary>
+            <p>Ja, we leveren ondertitels in .srt en gebrande versies zodat je meteen live kunt.</p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <section id="contact" class="section contact-section" aria-labelledby="contact-title">
+      <div class="container contact-grid">
+        <div>
+          <h2 id="contact-title">Contact</h2>
+          <p>Vertel ons wat je wilt bereiken. We reageren binnen één werkdag met een voorstel of vragenlijst.</p>
+          <div class="contact-alt">
+            <p><strong>E-mail:</strong> <a href="mailto:jouw@e-mail.nl">jouw@e-mail.nl</a></p>
+            <p><strong>Telefoon:</strong> <a href="tel:+31600000000">06-…</a></p>
+          </div>
+        </div>
+        <form id="contact-form" class="contact-form" action="https://formspree.io/f/your-form-id" method="POST" data-netlify="false" novalidate>
+          <div class="form-field">
+            <label for="naam">Naam<span aria-hidden="true">*</span></label>
+            <input type="text" id="naam" name="naam" required autocomplete="name" />
+            <span class="error" data-error-for="naam"></span>
+          </div>
+          <div class="form-field">
+            <label for="email">E-mail<span aria-hidden="true">*</span></label>
+            <input type="email" id="email" name="email" required autocomplete="email" inputmode="email" />
+            <span class="error" data-error-for="email"></span>
+          </div>
+          <div class="form-field">
+            <label for="telefoon">Telefoon</label>
+            <input type="tel" id="telefoon" name="telefoon" autocomplete="tel" inputmode="tel" />
+          </div>
+          <div class="form-field">
+            <label for="bedrijf">Bedrijf</label>
+            <input type="text" id="bedrijf" name="bedrijf" autocomplete="organization" />
+          </div>
+          <div class="form-field">
+            <label for="onderwerp">Onderwerp</label>
+            <input type="text" id="onderwerp" name="onderwerp" />
+          </div>
+          <div class="form-field">
+            <label for="bericht">Bericht<span aria-hidden="true">*</span></label>
+            <textarea id="bericht" name="bericht" rows="4" required></textarea>
+            <span class="error" data-error-for="bericht"></span>
+          </div>
+          <div class="form-field">
+            <label for="bestanden">Bestand toevoegen</label>
+            <input type="file" id="bestanden" name="bestanden" />
+          </div>
+          <div class="form-field honeypot" aria-hidden="true">
+            <label for="website">Laat dit veld leeg</label>
+            <input type="text" id="website" name="website" tabindex="-1" autocomplete="off" />
+          </div>
+          <div class="form-field checkbox-field">
+            <input type="checkbox" id="gdpr" name="gdpr" value="akkoord" required />
+            <label for="gdpr">Ik ga akkoord met verwerking van mijn gegevens t.b.v. contact.</label>
+            <span class="error" data-error-for="gdpr"></span>
+          </div>
+          <button type="submit" class="button button-primary">Versturen</button>
+          <p class="form-feedback" aria-live="polite" role="status"></p>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div>
+        <h2 class="footer-title">Gjaltema Films</h2>
+        <p>Videoproductiepartner in Groningen en Westerkwartier.</p>
+        <ul class="footer-contact">
+          <li><a href="mailto:jouw@e-mail.nl">jouw@e-mail.nl</a></li>
+          <li><a href="tel:+31600000000">06-…</a></li>
+          <li>Straat, Plaats</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Zakelijk</h3>
+        <ul class="footer-links">
+          <li><a href="#diensten">Diensten</a></li>
+          <li><a href="#portfolio">Portfolio</a></li>
+          <li><a href="#tarieven">Tarieven</a></li>
+          <li><a href="#faq">FAQ</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Informatie</h3>
+        <ul class="footer-links">
+          <li><a href="privacy.html">Privacyverklaring</a></li>
+          <li><a href="privacy.html#cookies">Cookiebeleid</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Bedrijfsgegevens</h3>
+        <p>KvK: nummer<br />BTW: nummer</p>
+        <div class="socials">
+          <a href="https://www.instagram.com/" aria-label="Instagram">Instagram</a>
+          <a href="https://www.youtube.com/" aria-label="YouTube">YouTube</a>
+          <a href="https://www.linkedin.com/" aria-label="LinkedIn">LinkedIn</a>
+        </div>
+      </div>
+    </div>
+    <p class="footer-bottom">&copy; <span id="year"></span> Gjaltema Films. Alle rechten voorbehouden.</p>
+  </footer>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "Gjaltema Films",
+    "description": "Videoproductiebedrijf uit Groningen en Westerkwartier: bedrijfsvideo's, events, drone-shots en social content.",
+    "areaServed": {
+      "@type": "Place",
+      "name": "Groningen en Westerkwartier"
+    },
+    "email": "mailto:jouw@e-mail.nl",
+    "telephone": "+31600000000",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Plaats",
+      "addressCountry": "NL"
+    },
+    "url": "https://www.gjaltemafilms.nl/",
+    "sameAs": [
+      "https://instagram.com/",
+      "https://youtube.com/",
+      "https://linkedin.com/"
+    ]
+  }
+  </script>
+  <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Gjaltema Films",
+  "short_name": "Gjaltema",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#121212",
+  "theme_color": "#121212",
+  "icons": [
+    {
+      "src": "assets/icons/favicon.svg",
+      "sizes": "64x64 128x128 256x256",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacyverklaring | Gjaltema Films</title>
+  <meta name="description" content="Lees hoe Gjaltema Films omgaat met privacy, persoonsgegevens en cookies." />
+  <meta name="theme-color" content="#121212" />
+  <link rel="icon" type="image/svg+xml" href="assets/icons/favicon.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body class="legal">
+  <a class="skip-link" href="#main">Direct naar inhoud</a>
+  <header class="site-header" id="top">
+    <div class="container">
+      <a class="brand" href="index.html" aria-label="Terug naar home">
+        <span class="brand-mark" aria-hidden="true">GF</span>
+        <span class="brand-text">Gjaltema Films</span>
+      </a>
+      <nav class="site-nav" aria-label="Hoofdmenu">
+        <a class="button button-secondary" href="index.html#contact">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" class="section">
+    <div class="container">
+      <h1>Privacyverklaring</h1>
+      <p>Laatste update: 12 juni 2024</p>
+      <p>Wij zijn Gjaltema Films, gevestigd in Groningen / Westerkwartier. We respecteren je privacy en gaan zorgvuldig om met persoonsgegevens. In deze verklaring lees je welke gegevens we verzamelen, met welk doel en hoe lang we deze bewaren.</p>
+
+      <h2>Welke gegevens verwerken we?</h2>
+      <ul>
+        <li>Contactgegevens zoals naam, e-mailadres en telefoonnummer.</li>
+        <li>Bedrijfsnaam en onderwerp van je aanvraag.</li>
+        <li>Berichtinhoud en eventueel meegezonden bestanden.</li>
+      </ul>
+
+      <h2>Waarvoor gebruiken we deze gegevens?</h2>
+      <ul>
+        <li>Om je aanvraag of offerteverzoek te beantwoorden.</li>
+        <li>Om afspraken te plannen en een voorstel op maat te maken.</li>
+        <li>Om werkzaamheden uit te voeren en te factureren.</li>
+      </ul>
+
+      <h2>Rechtsgrond</h2>
+      <p>We verwerken je gegevens op basis van toestemming en uitvoering van een (voorlopige) overeenkomst. Je kunt je toestemming altijd intrekken door ons te mailen op <a href="mailto:jouw@e-mail.nl">jouw@e-mail.nl</a>.</p>
+
+      <h2>Bewaartermijnen</h2>
+      <p>We bewaren contactaanvragen maximaal 24 maanden na het laatste contactmoment. Administratieve gegevens bewaren we zolang wettelijk verplicht is (meestal 7 jaar).</p>
+
+      <h2>Delen met derden</h2>
+      <p>We delen je gegevens alleen met partijen die ons helpen onze diensten te leveren, zoals boekhouding of hosting. Met deze verwerkers hebben we verwerkersovereenkomsten. We verkopen je gegevens nooit.</p>
+
+      <h2>Beveiliging</h2>
+      <p>We nemen passende maatregelen om misbruik, verlies en ongeautoriseerde toegang tegen te gaan. Denk aan versleutelde verbindingen, beveiligde opslag en beperkte toegang.</p>
+
+      <h2>Jouw rechten</h2>
+      <p>Je hebt het recht op inzage, correctie, verwijdering, beperking van de verwerking en dataportabiliteit. Wil je van deze rechten gebruikmaken? Mail ons via <a href="mailto:jouw@e-mail.nl">jouw@e-mail.nl</a>. We reageren binnen 14 dagen.</p>
+
+      <h2 id="cookies">Cookies</h2>
+      <p>Deze website gebruikt alleen functionele cookies die noodzakelijk zijn voor het functioneren van de site. Er worden geen marketing- of analytische cookies geplaatst en er worden geen gegevens gedeeld met derden voor advertentiedoeleinden.</p>
+
+      <h2>Wijzigingen</h2>
+      <p>We kunnen deze privacyverklaring aanpassen als de omstandigheden daarom vragen. De nieuwste versie vind je altijd op deze pagina.</p>
+
+      <h2>Contact</h2>
+      <p>Heb je vragen over deze verklaring of wil je een verzoek indienen? Neem contact op:</p>
+      <address>
+        Gjaltema Films<br />
+        Groningen / Westerkwartier<br />
+        E: <a href="mailto:jouw@e-mail.nl">jouw@e-mail.nl</a><br />
+        T: <a href="tel:+31600000000">06-…</a>
+      </address>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div>
+        <h2 class="footer-title">Gjaltema Films</h2>
+        <p>Videoproductiepartner in Groningen en Westerkwartier.</p>
+      </div>
+      <div>
+        <h3>Navigatie</h3>
+        <ul class="footer-links">
+          <li><a href="index.html#diensten">Diensten</a></li>
+          <li><a href="index.html#portfolio">Portfolio</a></li>
+          <li><a href="index.html#contact">Contact</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Bedrijfsgegevens</h3>
+        <p>KvK: nummer<br />BTW: nummer</p>
+      </div>
+    </div>
+    <p class="footer-bottom">&copy; <span id="year"></span> Gjaltema Films.</p>
+  </footer>
+  <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.gjaltemafilms.nl/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.gjaltemafilms.nl/index.html</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.gjaltemafilms.nl/privacy.html</loc>
+    <priority>0.5</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- build a conversion-focused single-page site featuring hero, services, portfolio, pricing, FAQ, and contact sections tailored to Gjaltema Films
- add responsive styling, accessibility enhancements, and interactive JS for the mobile menu, portfolio lightbox, and Formspree contact validation
- include privacy page, SVG assets, favicon/manifest, sitemap, robots, and a README with deployment and configuration guidance

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1aa5586e48332864f1891b407cd47