### PR TITLE
Use official logo asset in site header

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -102,27 +102,13 @@ ul, ol {
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.65rem;
-  font-weight: 600;
   color: var(--color-text);
 }
 
-.brand-mark {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.75rem;
-  background: var(--color-accent);
-  color: #121212;
-  font-family: var(--font-heading);
-  font-weight: 600;
-}
-
-.brand-text {
-  font-size: 1.05rem;
-  letter-spacing: 0.02em;
+.brand-logo {
+  display: block;
+  height: 2.75rem;
+  width: auto;
 }
 
 .site-nav {

--- a/index.html
+++ b/index.html
@@ -27,8 +27,13 @@
   <header class="site-header" id="top">
     <div class="container">
       <a class="brand" href="#top" aria-label="Gjaltema Films home">
-        <span class="brand-mark" aria-hidden="true">GF</span>
-        <span class="brand-text">Gjaltema Films</span>
+        <img
+          class="brand-logo"
+          src="LOGO.png"
+          width="502"
+          height="570"
+          alt="Gjaltema Films"
+        />
       </a>
       <nav class="site-nav" aria-label="Hoofdmenu">
         <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation">

--- a/privacy.html
+++ b/privacy.html
@@ -17,8 +17,13 @@
   <header class="site-header" id="top">
     <div class="container">
       <a class="brand" href="index.html" aria-label="Terug naar home">
-        <span class="brand-mark" aria-hidden="true">GF</span>
-        <span class="brand-text">Gjaltema Films</span>
+        <img
+          class="brand-logo"
+          src="LOGO.png"
+          width="502"
+          height="570"
+          alt="Gjaltema Films"
+        />
       </a>
       <nav class="site-nav" aria-label="Hoofdmenu">
         <a class="button button-secondary" href="index.html#contact">Contact</a>


### PR DESCRIPTION
## Summary
- replace the textual brand mark with the official logo image on the home and privacy pages
- add CSS to size the logo while removing unused brand mark/text styling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1b3693af4833284cf10b1c614ba11