### PR TITLE
Use LOGO.png branding asset across site

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,12 @@
   <meta property="og:title" content="Gjaltema Films" />
   <meta property="og:description" content="Strakke video die jouw verhaal laat werken. Videoproductie, events, drone en socials." />
   <meta property="og:url" content="https://www.gjaltemafilms.nl/" />
-  <meta property="og:image" content="assets/img/og-image.svg" />
+  <meta property="og:image" content="LOGO.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Gjaltema Films" />
   <meta name="twitter:description" content="Videoproductie in Groningen en Westerkwartier." />
-  <meta name="twitter:image" content="assets/img/og-image.svg" />
-  <link rel="icon" type="image/svg+xml" href="assets/icons/favicon.svg" />
+  <meta name="twitter:image" content="LOGO.png" />
+  <link rel="icon" type="image/png" href="LOGO.png" />
   <link rel="manifest" href="manifest.json" />
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/manifest.json
+++ b/manifest.json
@@ -7,9 +7,9 @@
   "theme_color": "#121212",
   "icons": [
     {
-      "src": "assets/icons/favicon.svg",
-      "sizes": "64x64 128x128 256x256",
-      "type": "image/svg+xml"
+      "src": "LOGO.png",
+      "sizes": "512x512",
+      "type": "image/png"
     }
   ]
 }

--- a/privacy.html
+++ b/privacy.html
@@ -6,7 +6,7 @@
   <title>Privacyverklaring | Gjaltema Films</title>
   <meta name="description" content="Lees hoe Gjaltema Films omgaat met privacy, persoonsgegevens en cookies." />
   <meta name="theme-color" content="#121212" />
-  <link rel="icon" type="image/svg+xml" href="assets/icons/favicon.svg" />
+  <link rel="icon" type="image/png" href="LOGO.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Poppins:wght@500;600;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- swap Open Graph and Twitter preview images to the new LOGO.png asset
- update the favicon reference on all pages to use LOGO.png
- align the web app manifest icon with LOGO.png so all surfaces share the same logo

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1b6cbd21083329ba4e7847eb8b211