### PR TITLE
Remove portfolio section and link CTA to Instagram

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,10 +4,6 @@
   const contactForm = document.getElementById('contact-form');
   const feedbackEl = contactForm?.querySelector('.form-feedback');
   const yearEl = document.getElementById('year');
-  const lightbox = document.querySelector('.lightbox');
-  const lightboxMedia = document.querySelector('[data-embed-target]');
-  const closeButton = document.querySelector('.lightbox-close');
-  const backdrop = document.querySelector('[data-lightbox-close]');
 
   if (yearEl) {
     yearEl.textContent = new Date().getFullYear();
@@ -140,43 +136,4 @@
     }
   });
 
-  const portfolioItems = document.querySelectorAll('.portfolio-item');
-  const openLightbox = (embedUrl) => {
-    if (!lightbox || !lightboxMedia) return;
-    const iframe = document.createElement('iframe');
-    iframe.src = embedUrl;
-    iframe.allow = 'autoplay; fullscreen; picture-in-picture';
-    iframe.title = 'Video player';
-    iframe.loading = 'lazy';
-    lightboxMedia.innerHTML = '';
-    lightboxMedia.appendChild(iframe);
-    lightbox.dataset.state = 'visible';
-    document.body.style.overflow = 'hidden';
-    closeButton?.focus();
-  };
-
-  const closeLightbox = () => {
-    if (!lightbox || !lightboxMedia) return;
-    lightbox.dataset.state = 'hidden';
-    lightboxMedia.innerHTML = '';
-    document.body.style.overflow = '';
-  };
-
-  portfolioItems.forEach((item) => {
-    item.addEventListener('click', () => {
-      const embed = item.getAttribute('data-embed');
-      if (embed) {
-        openLightbox(embed);
-      }
-    });
-  });
-
-  closeButton?.addEventListener('click', closeLightbox);
-  backdrop?.addEventListener('click', closeLightbox);
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape' && lightbox?.dataset.state === 'visible') {
-      closeLightbox();
-    }
-  });
 })();

--- a/index.html
+++ b/index.html
@@ -37,7 +37,6 @@
         </button>
         <ul id="primary-navigation" class="nav-list">
           <li><a href="#diensten">Diensten</a></li>
-          <li><a href="#portfolio">Portfolio</a></li>
           <li><a href="#werkwijze">Werkwijze</a></li>
           <li><a href="#over-ons">Over ons</a></li>
           <li><a href="#tarieven">Tarieven</a></li>
@@ -57,7 +56,7 @@
           <p class="lead">Moi! even voorstellen, Gjaltema Films. Ik help kleinere bedrijven, verenigingen, organisaties, evenementen én personen om hun ideeën zichtbaar te maken met video die werkt. Van idee tot montage, inclusief dronebeelden waar dat kan. Ik verdiep mij in jouw verhaal en vertaal dat zonder poespas naar beeld. Doeltreffend, kostenefficiënt en afgestemd op wat jij écht nodig hebt.</p>
           <div class="cta-group">
             <a class="button button-primary" href="#contact">Offerte aanvragen</a>
-            <a class="button button-secondary" href="#portfolio">Portfolio bekijken</a>
+            <a class="button button-secondary" href="https://www.instagram.com/gjaltemafilms/" target="_blank" rel="noopener">Portfolio bekijken</a>
           </div>
           <dl class="trust-points">
             <div>
@@ -121,87 +120,6 @@
             </ul>
           </article>
         </div>
-      </div>
-    </section>
-
-    <section id="portfolio" class="section section-alt" aria-labelledby="portfolio-title">
-      <div class="container">
-        <div class="section-heading">
-          <h2 id="portfolio-title">Portfolio</h2>
-          <p>Selectie van recente producties. Vraag ons gerust naar meer cases of referenties.</p>
-        </div>
-        <div class="portfolio-grid">
-          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=dQw4w9WgXcQ" aria-label="Open project Drone overzicht">
-            <figure>
-              <img src="assets/img/portfolio/project-1.svg" width="600" height="400" loading="lazy" alt="Drone overzicht projectthumbnail" />
-              <figcaption>
-                <span class="tag">Drone</span>
-                <span class="title">Drone overzicht</span>
-                <span class="description">Luchtbeelden van bedrijfsterrein in Westerkwartier.</span>
-              </figcaption>
-            </figure>
-          </button>
-          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=oHg5SJYRHA0" aria-label="Open project Event hoogtepunten">
-            <figure>
-              <img src="assets/img/portfolio/project-2.svg" width="600" height="400" loading="lazy" alt="Event hoogtepunten projectthumbnail" />
-              <figcaption>
-                <span class="tag">Event</span>
-                <span class="title">Event hoogtepunten</span>
-                <span class="description">Aftermovie van congres met interviews en sfeer.</span>
-              </figcaption>
-            </figure>
-          </button>
-          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=ub82Xb1C8os" aria-label="Open project Bedrijfsshoot">
-            <figure>
-              <img src="assets/img/portfolio/project-3.svg" width="600" height="400" loading="lazy" alt="Bedrijfsshoot projectthumbnail" />
-              <figcaption>
-                <span class="tag">Videoproductie</span>
-                <span class="title">Bedrijfsshoot</span>
-                <span class="description">Employer branding video voor techbedrijf.</span>
-              </figcaption>
-            </figure>
-          </button>
-          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=VV1XWJN3nJo" aria-label="Open project Social snippet">
-            <figure>
-              <img src="assets/img/portfolio/project-4.svg" width="600" height="400" loading="lazy" alt="Social snippet projectthumbnail" />
-              <figcaption>
-                <span class="tag">Social</span>
-                <span class="title">Social snippet</span>
-                <span class="description">Maandelijkse short-form content voor campagne.</span>
-              </figcaption>
-            </figure>
-          </button>
-          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=ZZ5LpwO-An4" aria-label="Open project Productvideo">
-            <figure>
-              <img src="assets/img/portfolio/project-5.svg" width="600" height="400" loading="lazy" alt="Productvideo projectthumbnail" />
-              <figcaption>
-                <span class="tag">Product</span>
-                <span class="title">Productvideo</span>
-                <span class="description">Lancering van nieuw product met detailshots.</span>
-              </figcaption>
-            </figure>
-          </button>
-          <button class="portfolio-item" data-embed="https://www.youtube.com/watch?v=2Z4m4lnjxkY" aria-label="Open project Aftermovie">
-            <figure>
-              <img src="assets/img/portfolio/project-6.svg" width="600" height="400" loading="lazy" alt="Aftermovie projectthumbnail" />
-              <figcaption>
-                <span class="tag">Event</span>
-                <span class="title">Aftermovie</span>
-                <span class="description">Festivalvastlegging met drone en crowdshots.</span>
-              </figcaption>
-            </figure>
-          </button>
-        </div>
-      </div>
-      <div class="lightbox" data-state="hidden" role="dialog" aria-modal="true" aria-labelledby="lightbox-title">
-        <div class="lightbox-content">
-          <button class="lightbox-close" type="button" aria-label="Sluit portfolio video">&times;</button>
-          <div class="lightbox-body" id="lightbox-body" role="document">
-            <h3 id="lightbox-title">Portfolio video</h3>
-            <div class="lightbox-media" data-embed-target></div>
-          </div>
-        </div>
-        <div class="lightbox-backdrop" data-lightbox-close></div>
       </div>
     </section>
 
@@ -396,7 +314,6 @@
         <h3>Zakelijk</h3>
         <ul class="footer-links">
           <li><a href="#diensten">Diensten</a></li>
-          <li><a href="#portfolio">Portfolio</a></li>
           <li><a href="#tarieven">Tarieven</a></li>
           <li><a href="#faq">FAQ</a></li>
         </ul>

--- a/privacy.html
+++ b/privacy.html
@@ -88,7 +88,7 @@
         <h3>Navigatie</h3>
         <ul class="footer-links">
           <li><a href="index.html#diensten">Diensten</a></li>
-          <li><a href="index.html#portfolio">Portfolio</a></li>
+          <li><a href="index.html#werkwijze">Werkwijze</a></li>
           <li><a href="index.html#contact">Contact</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- verwijder de portfolio-sectie en alle navigatielinks ernaartoe
- link de hero-CTA naar het Instagram-profiel voor portfolio-inhoud en werk de footers bij
- ruim de JavaScript lightbox-logica op die uitsluitend voor de portfolio werd gebruikt

## Testing
- niet uitgevoerd (statistische site)

------
https://chatgpt.com/codex/tasks/task_e_68d4460b262c83328578ac7835914614