### PR TITLE
Remove Werkwijze section and navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,6 @@
         </button>
         <ul id="primary-navigation" class="nav-list">
           <li><a href="#diensten">Diensten</a></li>
-          <li><a href="#werkwijze">Werkwijze</a></li>
           <li><a href="#over-ons">Over ons</a></li>
           <li><a href="#tarieven">Tarieven</a></li>
           <li><a href="#faq">FAQ</a></li>
@@ -120,37 +119,6 @@
             </ul>
           </article>
         </div>
-      </div>
-    </section>
-
-    <section id="werkwijze" class="section" aria-labelledby="werkwijze-title">
-      <div class="container">
-        <div class="section-heading">
-          <h2 id="werkwijze-title">Werkwijze</h2>
-          <p>Van kennismaking tot oplevering houden we het helder en wendbaar.</p>
-        </div>
-        <ol class="process-list">
-          <li>
-            <h3>Kennismaking</h3>
-            <p>We starten met een gesprek over doelen, doelgroep en planning. We denken mee over formats en kanalen.</p>
-          </li>
-          <li>
-            <h3>Plan &amp; script</h3>
-            <p>We werken een script of outline uit, eventueel verwerkt in een concept.</p>
-          </li>
-          <li>
-            <h3>Opnames</h3>
-            <p> We filmen met de juiste crew, gear en, indien gewenst, drone. Veilig en efficiënt.</p>
-          </li>
-          <li>
-            <h3>Montage &amp; feedback</h3>
-            <p>We monteren snel, delen previews en verwerken revisies in overleg.</p>
-          </li>
-          <li>
-            <h3>Oplevering</h3>
-            <p>We leveren bestanden voor web, socials en archief. Inclusief ondertiteling en formaten.</p>
-          </li>
-        </ol>
       </div>
     </section>
 

--- a/privacy.html
+++ b/privacy.html
@@ -88,7 +88,6 @@
         <h3>Navigatie</h3>
         <ul class="footer-links">
           <li><a href="index.html#diensten">Diensten</a></li>
-          <li><a href="index.html#werkwijze">Werkwijze</a></li>
           <li><a href="index.html#contact">Contact</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- remove the Werkwijze navigation link from the homepage menu
- delete the Werkwijze section content from the homepage
- update the privacy page footer navigation to exclude the Werkwijze link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d447617e5c8332ba249b3b6beeca1e